### PR TITLE
Change module name to customerio/raven-go

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ event/error logging system.
 ## Installation
 
 ```text
-go get github.com/richdawe-cio/raven-go
+go get github.com/customerio/raven-go
 ```
 
 Note: Go 1.22 and newer are supported. Earlier and newer versions may work, but have not been tested with this fork.
@@ -39,12 +39,12 @@ Unfortunately this results in a few test failures. Since this fork has minimally
 
 ```
 --- FAIL: TestFunctionName (0.00s)
-    stacktrace_test.go:50: incorrect package; got github.com/richdawe-cio/raven-go, want .
+    stacktrace_test.go:50: incorrect package; got github.com/customerio/raven-go, want .
 --- FAIL: TestStacktraceFrame (0.00s)
-    stacktrace_test.go:84: incorrect Module: github.com/richdawe-cio/raven-go
+    stacktrace_test.go:84: incorrect Module: github.com/customerio/raven-go
     stacktrace_test.go:87: incorrect Lineno: 18
     stacktrace_test.go:90: expected InApp to be true
 --- FAIL: TestStacktraceErrorsWithStack (0.00s)
-    stacktrace_test.go:141: incorrect Module: github.com/richdawe-cio/raven-go
-    stacktrace_test.go:150: incorrect Module: github.com/richdawe-cio/raven-go
+    stacktrace_test.go:141: incorrect Module: github.com/customerio/raven-go
+    stacktrace_test.go:150: incorrect Module: github.com/customerio/raven-go
 ```

--- a/example/example.go
+++ b/example/example.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/richdawe-cio/raven-go"
+	"github.com/customerio/raven-go"
 )
 
 func trace() *raven.Stacktrace {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/richdawe-cio/raven-go
+module github.com/customerio/raven-go
 
 go 1.22
 


### PR DESCRIPTION
The module has been reparented from `richdawe-cio/raven-go` to `customerio/raven-go`, so update the module name to match.